### PR TITLE
Fix overflowing species image

### DIFF
--- a/grails-app/assets/stylesheets/show.css
+++ b/grails-app/assets/stylesheets/show.css
@@ -53,6 +53,7 @@
 
 .taxon-summary-gallery .main-img img {
     max-height: 500px;
+    max-width: 100%;
     margin: 0 auto;
 }
 


### PR DESCRIPTION
* Prevent the main image on the species page from overflowing.